### PR TITLE
added monthday function and test

### DIFF
--- a/src/time.jl
+++ b/src/time.jl
@@ -700,13 +700,20 @@ Simultaneously return the year, month and day parts of `dt`.
 yearmonthday(dt::AbstractCFDateTime) = (Dates.year(dt),Dates.month(dt),Dates.day(dt))
 
 """
-    yearmonth(dt::AbstractCFDateTime) -> (Int64, Int64, Int64)
+    yearmonth(dt::AbstractCFDateTime) -> (Int64, Int64)
 
 Simultaneously return the year and month parts of `dt`.
 """
 yearmonth(dt::AbstractCFDateTime) = (Dates.year(dt),Dates.month(dt))
 
-export daysinmonth, daysinyear, yearmonthday, yearmonth
+"""
+    monthday(dt::AbstractCFDateTime) -> (Int64, Int64)
+
+Simultaneously return the month and day parts of `dt`.
+"""
+monthday(dt::AbstractCFDateTime) = (Dates.month(dt),Dates.day(dt))
+
+export daysinmonth, daysinyear, yearmonthday, yearmonth, monthday
 
 export DateTimeStandard, DateTimeJulian, DateTimeProlepticGregorian,
     DateTimeAllLeap, DateTimeNoLeap, DateTime360Day, AbstractCFDateTime

--- a/test/test_time.jl
+++ b/test/test_time.jl
@@ -356,6 +356,7 @@ for T in [DateTimeStandard, DateTimeJulian, DateTimeProlepticGregorian,
           DateTimeAllLeap, DateTimeNoLeap, DateTime360Day]
     @test Dates.yearmonthday(T(2004,1,2)) == (2004, 1, 2)
     @test Dates.yearmonth(T(2004,1,2)) == (2004, 1)
+    @test Dates.monthday(T(2004,1,2)) == (1, 2)
 
     # test constructor with argument which are not Int64
     @test T(Int16(2000),Int32(1),UInt8(1)) == T(2000,1,1)


### PR DESCRIPTION
This PR introduce `monthday` function that returns a Tuple of month and day.

Note that there seem to be an error when launching the tests. Apparently, it fails when trying to buiold a `DateTime360Day` time

```julia
T=DateTime360Day
DateTime360Day
Dates.monthday(T(2004,1,2))
ERROR: MethodError: no method matching days(::DateTime360Day)
Closest candidates are:
  days(::DateTime) at /home/proy/Programmes/julia1.0/usr/share/julia/stdlib/v1.0/Dates/src/accessors.jl:48
  days(::Date) at /home/proy/Programmes/julia1.0/usr/share/julia/stdlib/v1.0/Dates/src/accessors.jl:47
  days(::Dates.CompoundPeriod) at /home/proy/Programmes/julia1.0/usr/share/julia/stdlib/v1.0/Dates/src/periods.jl:491
  ...
Stacktrace:
 [1] monthday(::DateTime360Day) at /home/proy/Programmes/julia1.0/usr/share/julia/stdlib/v1.0/Dates/src/accessors.jl:67
 [2] top-level scope at none:0
```
