### PR TITLE
Improve README, add TOC, add alias NCDataset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 keywords = ["netcdf", "climate and forecast conventions", "oceanography", "meteorology", "climatology", "opendap"]
 license = "MIT"
 desc = "Load and create NetCDF files in Julia"
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ This might be useful in an interactive session. However, the file `test.nc` is n
 An alternative way to ensure the file has been closed is to use a `do` block: the file will be closed automatically when leaving the block.
 
 ```julia
+data =
 Dataset(filename,"r") do ds
-    data = ds["temperature"][:,:]
+    ds["temperature"][:,:]
 end # ds is closed
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,46 @@ Variables
 [...]
 ```
 
+## Load a netCDF file
+
+Loading a variable with known structure can be achieved by accessing the variables and attributes directly by their name.
+
+```julia
+# The mode "r" stands for read-only. The mode "r" is the default mode and the parameter can be omitted.
+ds = Dataset("/tmp/test.nc","r")
+v = ds["temperature"]
+
+# load a subset
+subdata = v[10:30,30:5:end]
+
+# load all data
+data = v[:,:]
+
+# load all data ignoring attributes like scale_factor, add_offset, _FillValue and time units
+data2 = v.var[:,:]
+
+
+# load an attribute
+unit = v.attrib["units"]
+close(ds)
+```
+
+In the example above, the subset can also be loaded with:
+
+```julia
+subdata = Dataset("/tmp/test.nc")["temperature"][10:30,30:5:end]
+```
+
+This might be useful in an interactive session. However, the file `test.nc` is not closed, which can be a problem if you open many files. On Linux the number of opened files is often limited to 1024 (soft limit). If you write to a file, you should also always close the file to make sure that the data is properly written to the disk.
+
+An alternative way to ensure the file has been closed is to use a `do` block: the file will be closed automatically when leaving the block.
+
+```julia
+Dataset(filename,"r") do ds
+    data = ds["temperature"][:,:]
+end # ds is closed
+```
+
 ## Create a netCDF file
 
 The following gives an example of how to create a netCDF file by defining dimensions, variables and attributes.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Dataset("/tmp/test2.nc","c",attrib = ["title" => "this is a test file"]) do ds
 end
 ```
 
-## Edit an existing netCDF
+## Edit an existing netCDF file
 
 When you need to modify the variables or the attributes of a netCDF, you have
 to open it with the `"a"` option. Here of instance we add a global attribute *creator* to the

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ using Pkg
 Pkg.add("NCDatasets")
 ```
 
-## Exploring the content of a netCDF file
+# Manual
+
+* [Explore the content of a netCDF file](#explore-the-content-of-a-netcdf-file)
+* [Load a netCDF file](#load-a-netcdf-file)
+* [Create a netCDF file](#create-a-netcdf-file)
+* [Edit an existing netCDF file](#edit-an-existing-netcdf-file)
+
+## Explore the content of a netCDF file
 
 Before reading the data from a netCDF file, it is often useful to explore the list of variables and attributes defined in it.
 
@@ -164,7 +171,7 @@ Dataset("/tmp/test2.nc","c",attrib = ["title" => "this is a test file"]) do ds
 end
 ```
 
-## Editing an existing netCDF
+## Edit an existing netCDF
 
 When you need to modify the variables or the attributes of a netCDF, you have
 to open it with the `"a"` option. Here of instance we add a global attribute *creator* to the
@@ -175,50 +182,6 @@ ds = Dataset("/tmp/test.nc","a")
 ds.attrib["creator"] = "your name"
 close(ds);
 ```
-
-
-
-## Load a file
-
-Loading a variable with known structure can be achieved by accessing the variables and attributes directly by their name.
-
-```julia
-# The mode "r" stands for read-only. The mode "r" is the default mode and the parameter can be omitted.
-ds = Dataset("/tmp/test.nc","r")
-v = ds["temperature"]
-
-# load a subset
-subdata = v[10:30,30:5:end]
-
-# load all data
-data = v[:,:]
-
-# load all data ignoring attributes like scale_factor, add_offset, _FillValue and time units
-data2 = v.var[:,:]
-
-
-# load an attribute
-unit = v.attrib["units"]
-close(ds)
-```
-
-In the example above, the subset can also be loaded with:
-
-```julia
-subdata = Dataset("/tmp/test.nc")["temperature"][10:30,30:5:end]
-```
-
-This might be useful in an interactive session. However, the file `test.nc` is not closed, which can be a problem if you open many files. On Linux the number of opened files is often limited to 1024 (soft limit). If you write to a file, you should also always close the file to make sure that the data is properly written to the disk.
-
-An alternative way to ensure the file has been closed is to use a `do` block: the file will be closed automatically when leaving the block.
-
-```julia
-Dataset(filename,"r") do ds
-    data = ds["temperature"][:,:]
-end # ds is closed
-```
-
-
 
 
 # Filing an issue

--- a/README.md
+++ b/README.md
@@ -46,20 +46,26 @@ Pkg.add("NCDatasets")
 
 Before reading the data from a netCDF file, it is often useful to explore the list of variables and attributes defined in it.
 
-For interactive use, the following commands (without ending semicolon) display the content of the file similarly to `ncdump -h file.nc`
+For interactive use, the following commands (without ending semicolon) display the content of the file similarly to `ncdump -h file.nc`:
 
 ```julia
 using NCDatasets
 ds = Dataset("file.nc")
 ```
 
-The following displays the information just for the variable `varname` and for the global attributes:
+This creates the central structure of NCDatasets.jl, `Dataset`, which represents the contents of the netCDF file (without immediatelly loading everything in memory). `NCDataset` is an alias for `Dataset`.
+
+The following displays the information just for the variable `varname`:
 
 ```julia
 ds["varname"]
+```
+
+while to get the global attributes you can do:
+```julia
 ds.attrib
 ```
-which produces a listing the following:
+which produces a listing like:
 
 ```
 Dataset: file.nc

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -133,6 +133,8 @@ mutable struct Dataset <: AbstractDataset
     group::Groups
 end
 
+"Alias to `Dataset`"
+const NCDataset = Dataset
 
 # Mapping between NetCDF types and Julia types
 const jlType = Dict(

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -1736,7 +1736,7 @@ function nomissing(da::Array{Union{T,Missing},N},value) where {T,N}
 end
 
 
-export defVar, defDim, Dataset, close, sync, variable, dimnames, name,
+export defVar, defDim, Dataset, NCDataset, close, sync, variable, dimnames, name,
     deflate, chunking, checksum, fillvalue, fillmode, ncgen
 export nomissing
 export varbyattrib

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,8 +24,8 @@ println("NetCDF version: ",NCDatasets.nc_inq_libvers())
 
     ds = Dataset(filename)
     ds2 = NCDatasets.NCDataset(filename)
-    @test ds === ds2
     v = ds["var"]
+    @test v[:] == ds2["var"][:]
 
     A = v[:,:]
     @test A == data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ println("NetCDF version: ",NCDatasets.nc_inq_libvers())
     end
 
     ds = Dataset(filename)
-    ds2 = NCDataset.NCDataset(filename)
+    ds2 = NCDatasets.NCDataset(filename)
     @test ds === ds2
     v = ds["var"]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using Dates
 using Printf
 using Compat
+using Random
 
 println("NetCDF library: ",NCDatasets.libnetcdf)
 println("NetCDF version: ",NCDatasets.nc_inq_libvers())
@@ -11,7 +12,7 @@ println("NetCDF version: ",NCDatasets.nc_inq_libvers())
     global v
 
     sz = (123,145)
-    data = randn(sz)
+    data = randn(MersenneTwister(152), sz)
 
     filename = tempname()
     ds = Dataset(filename,"c") do ds
@@ -22,6 +23,8 @@ println("NetCDF version: ",NCDatasets.nc_inq_libvers())
     end
 
     ds = Dataset(filename)
+    ds2 = NCDataset.NCDataset(filename)
+    @test ds === ds2
     v = ds["var"]
 
     A = v[:,:]


### PR DESCRIPTION
With this PR I am hoping to improve the README a bit by adding a table of contents, re-arranging things for the docs to be a bit more intuitive and adding slightly more info here and there.

I am also adding the `NCDataset` alias (if you approve) for two reasons:
1. In DynamicalSystems.jl we also use the same name, `Dataset` for a central structure.
2. Because it is typical that a julia package "ThisThings.jl" would define a central structure `ThisThing` (without final s).

