### PR TITLE
Improve `nomissing` functionality

### DIFF
--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -477,7 +477,7 @@ function nomissing(da::AbstractArray{Union{T,Missing},N}) where {T,N}
     end
 end
 
-nomissing(a::AbstractArray{T,N}) where {T<:Union{Number, String, AbstractDate}, N} = a
+nomissing(a::AbstractArray{T,N}) where {T<:Union{Number, AbstractString, TimeType}, N} = a
 
 """
     a = nomissing(da,value)

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -459,8 +459,8 @@ Return the values of the array `da` of type `Array{Union{T,Missing},N}`
 element type. It raises an error if the array contains at least one missing value.
 
 """
-function nomissing(da::Array{Union{T,Missing},N}) where {T,N}
-    if any(ismissing.(da))
+function nomissing(da::AbstractArray{Union{T,Missing},N}) where {T,N}
+    if any(ismissing, da)
         error("arrays contains missing values (values equal to the fill values attribute in the NetCDF file)")
     end
     if VERSION >= v"1.2"

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -477,6 +477,8 @@ function nomissing(da::AbstractArray{Union{T,Missing},N}) where {T,N}
     end
 end
 
+nomissing(a::AbstractArray{T,N}) where {T<:Union{Number, String, AbstractDate}, N} = a
+
 """
     a = nomissing(da,value)
 

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -477,7 +477,7 @@ function nomissing(da::AbstractArray{Union{T,Missing},N}) where {T,N}
     end
 end
 
-nomissing(a::AbstractArray{T,N}) where {T<:Union{Number, AbstractString, TimeType}, N} = a
+nomissing(a::AbstractArray) = a
 
 """
     a = nomissing(da,value)


### PR DESCRIPTION
1. Improves performance of searching for missings in `da`.
2. Allows the user to pass in reshaped arrays, which are e.g. the result of `dropdims` function, after one has e.g. taken a mean across a dimension.