### PR TITLE
bump CondaBinDeps dependency, bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 keywords = ["netcdf", "climate and forecast conventions", "oceanography", "meteorology", "climatology", "opendap"]
 license = "MIT"
 desc = "Load and create NetCDF files in Julia"
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 BinDeps = "0.8, 1"
 CFTime = "0.0.3, 0.1, 1"
-CondaBinDeps = "0.1"
+CondaBinDeps = "0.1, 0.2"
 DataStructures = "0.17"
 julia = "0.7, 1"
 


### PR DESCRIPTION
I wonder if your package really depends on `Printf` and `Random`, or whether these are only used in the tests. For test dependencies, you have the `[extras]` section, anyway, so maybe you could reduce the amount of declared package dependencies.