### PR TITLE
do not throw when closing closed NCDataset

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -80,6 +80,6 @@ function Base.show(io::IO, a::BaseAttributes; indent = "  ")
                 return
             end
         end
-        rethrow
+        rethrow()
     end
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -329,7 +329,17 @@ to the disk.
 """
 function Base.close(ds::NCDataset)
     @debug "closing netCDF NCDataset $(ds.ncid) $(NCDatasets.path(ds))"
-    nc_close(ds.ncid)
+    try
+        nc_close(ds.ncid)
+    catch err
+        # like Base, allow close on closed file
+        if isa(err,NetCDFError)
+            if err.code == NC_EBADID
+                return ds
+            end
+        end
+        rethrow()
+    end
     # prevent finalize to close file as ncid can reused for future files
     ds.ncid = -1
     return ds

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -440,7 +440,7 @@ function Base.show(io::IO,ds::AbstractDataset; indent="")
                 return
             end
         end
-        rethrow
+        rethrow()
     end
 
     print(io,indent,"Group: ",groupname(ds),"\n")

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -470,7 +470,7 @@ function Base.show(io::IO,v::AbstractVariable; indent="")
                     return
                 end
             end
-            rethrow
+            rethrow()
         end
     sz = size(v)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,8 @@ println("NetCDF version: ",NCDatasets.nc_inq_libvers())
     # test sync
     NCDatasets.sync(ds)
     NCDatasets.close(ds)
+    # close on closed file should not throw
+    NCDatasets.close(ds)
 
     # Load a file (with unknown structure)
 


### PR DESCRIPTION
This copies the behavior of `Base.close` on file handles:

```julia
julia> io = open("asd","w")
IOStream(<file asd>)

julia> close(io)

julia> close(io)

julia>
```

And is more convenient for interactive use if you can't quite remember if you already closed a `NCDataset`.

The first commit fixes an issue in the usage of `rethrow`, though I guess this was rarely triggered.