### PR TITLE
Change attribute color from blue to cyan

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -70,7 +70,7 @@ function Base.show(io::IO, a::BaseAttributes; indent = "  ")
         # use the same order of attributes than in the NetCDF file
         for (attname,attval) in a
             print(io,indent,@sprintf("%-20s = ",attname))
-            printstyled(io, @sprintf("%s",attval),color=:blue)
+            printstyled(io, @sprintf("%s",attval),color=:cyan)
             print(io,"\n")
         end
     catch err


### PR DESCRIPTION
This is just a suggestion, but I think cyan works better with dark backgrounds (blue is almost unreadable for me sometimes), while it still works with lighter/white backgrounds. 

Here are some screenshots of different backgrounds (I mostly use the last one, where the blue output is really hard to read for me):

<img width="402" alt="Screen Shot 2021-01-15 at 11 51 52 am" src="https://user-images.githubusercontent.com/4486578/104666560-4d2c7680-5728-11eb-9f56-81b1a94de078.png">
<img width="388" alt="Screen Shot 2021-01-15 at 11 52 27 am" src="https://user-images.githubusercontent.com/4486578/104666565-4f8ed080-5728-11eb-8fc2-6d6a374f8d48.png">
<img width="395" alt="Screen Shot 2021-01-15 at 11 53 11 am" src="https://user-images.githubusercontent.com/4486578/104666570-51589400-5728-11eb-8abe-e31b301726ae.png">
