### PR TITLE
verify1.6-nightly tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         version:
           - '1.3'
+          - '1.6-nightly'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
On NetCDF.jl Windows CI is failing with an unclear error: 
https://github.com/JuliaGeo/NetCDF.jl/pull/140/checks?check_run_id=1913665717#step:6:55

Testing here to see if it is the build or not.