### PR TITLE
Reduce compilation time

### DIFF
--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -56,6 +56,7 @@ include("cfconventions.jl")
 include("defer.jl")
 include("multifile.jl")
 include("ncgen.jl")
+include("precompile.jl")
 
 
 end # module

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -251,7 +251,7 @@ export defVar
 
 function _boundsParentVar(ds,name)
     # get from cache is available
-    if ds._boundsmap !== nothing
+    if length(values(ds._boundsmap)) === 0
         return get(ds._boundsmap,name,"")
     else
         for vname in keys(ds)
@@ -352,6 +352,7 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         calendar,time_origin,time_factor = _calendar_time(v.attrib)
     else
         calendar,time_origin,time_factor = _calendar_time(variable(ds,parentname).attrib)
+        @show calendar
         calendar,time_origin,time_factor = _calendar_time(
             v.attrib;
             calendar = calendar,
@@ -373,14 +374,13 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         end
     end
 
-
-    storage_attrib = Dict{Symbol,Any}(
-        :fillvalue => fillvalue,
-        :scale_factor => scale_factor,
-        :add_offset => add_offset,
-        :calendar => calendar,
-        :time_origin => time_origin,
-        :time_factor => time_factor,
+    storage_attrib = (
+        fillvalue = fillvalue,
+        scale_factor = scale_factor,
+        add_offset = add_offset,
+        calendar = calendar,
+        time_origin = time_origin,
+        time_factor = time_factor,
     )
 
     rettype = _get_rettype(ds, calendar, fillvalue, scaledtype)

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -644,10 +644,3 @@ Base.show(io::IO,v::CFVariable; indent="") = Base.show(io::IO,v.var; indent=inde
 Base.show(io::IO,::MIME"text/plain",v::Union{Variable,CFVariable}) = show(io,v)
 
 Base.display(v::Union{Variable,CFVariable}) = show(stdout,v)
-
-
-precompile(NCDataset{Nothing}, (String,))
-precompile(getindex, (NCDataset{Nothing}, String))
-precompile(getindex, (NCDataset{Nothing}, Symbol))
-precompile(variable, (NCDataset{Nothing}, String))
-precompile(NCDatasets.Variable, (Float32, 3, NCDataset))

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -252,7 +252,7 @@ export defVar
 function _boundsParentVar(ds,name)
     # get from cache is available
     if ds._boundsmap !== nothing
-        return get(ds._boundsmap,name,nothing)
+        return get(ds._boundsmap,name,"")
     else
         for vname in keys(ds)
             v = variable(ds,vname)
@@ -262,7 +262,7 @@ function _boundsParentVar(ds,name)
             end
         end
 
-        return nothing
+        return ""
     end
 end
 
@@ -348,19 +348,18 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
     # units and calendar from parent variables
     parentname = _boundsParentVar(ds,varname)
 
-    if parentname === nothing
-        calendar = nothing
-        time_origin = nothing
-        time_factor = nothing
+    if parentname === ""
+        calendar,time_origin,time_factor = _calendar_time(v.attrib)
     else
         calendar,time_origin,time_factor = _calendar_time(variable(ds,parentname).attrib)
+        calendar,time_origin,time_factor = _calendar_time(
+            v.attrib;
+            calendar = calendar,
+            time_origin = time_origin,
+            time_factor = time_factor
+        )
     end
 
-    calendar,time_origin,time_factor = _calendar_time(
-        v.attrib;
-        calendar = calendar,
-        time_origin = time_origin,
-        time_factor = time_factor)
 
     scaledtype = eltype(v)
 
@@ -399,7 +398,7 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         end
     end
 
-    if fillvalue != nothing
+    if fillvalue !== nothing
         rettype = Union{Missing,rettype}
     end
 

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -348,7 +348,7 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
     # units and calendar from parent variables
     parentname = _boundsParentVar(ds,varname)
 
-    if parentname == nothing
+    if parentname === nothing
         calendar = nothing
         time_origin = nothing
         time_factor = nothing
@@ -365,11 +365,11 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
     scaledtype = eltype(v)
 
     if eltype(v) <: Number
-        if scale_factor != nothing
+        if scale_factor !== nothing
             scaledtype = promote_type(scaledtype, typeof(scale_factor))
         end
 
-        if add_offset != nothing
+        if add_offset !== nothing
             scaledtype = promote_type(scaledtype, typeof(add_offset))
         end
     end
@@ -377,7 +377,7 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
     rettype = scaledtype
 
     # rettype can be a date if calendar is different from nothing
-    if calendar != nothing
+    if calendar !== nothing
         DT = nothing
         try
             DT = CFTime.timetype(calendar)
@@ -403,13 +403,13 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         rettype = Union{Missing,rettype}
     end
 
-    storage_attrib = (
-        fillvalue = fillvalue,
-        scale_factor = scale_factor,
-        add_offset = add_offset,
-        calendar = calendar,
-        time_origin = time_origin,
-        time_factor = time_factor,
+    storage_attrib = Dict{Symbol,Any}(
+        :fillvalue => fillvalue,
+        :scale_factor => scale_factor,
+        :add_offset => add_offset,
+        :calendar => calendar,
+        :time_origin => time_origin,
+        :time_factor => time_factor,
     )
 
     return CFVariable{rettype,ndims(v),typeof(v),typeof(v.attrib),typeof(storage_attrib)}(
@@ -450,18 +450,18 @@ checksum(v::CFVariable) = checksum(v.var)
 
 fillmode(v::CFVariable) = fillmode(v.var)
 
-fillvalue(v::CFVariable) = v._storage_attrib.fillvalue
-scale_factor(v::CFVariable) = v._storage_attrib.scale_factor
-add_offset(v::CFVariable) = v._storage_attrib.add_offset
-time_origin(v::CFVariable) = v._storage_attrib.time_origin
-calendar(v::CFVariable) = v._storage_attrib.calendar
+fillvalue(v::CFVariable) = v._storage_attrib[:fillvalue]
+scale_factor(v::CFVariable) = v._storage_attrib[:scale_factor]
+add_offset(v::CFVariable) = v._storage_attrib[:add_offset]
+time_origin(v::CFVariable) = v._storage_attrib[:time_origin]
+calendar(v::CFVariable) = v._storage_attrib[:calendar]
 """"
     tf = time_factor(v::CFVariable)
 
 The time unit in milliseconds. E.g. seconds would be 1000., days would be 86400000.
 The result can also be `nothing` if the variable has no time units.
 """
-time_factor(v::CFVariable) = v._storage_attrib.time_factor
+time_factor(v::CFVariable) = v._storage_attrib[:time_factor]
 
 
 ############################################################
@@ -644,3 +644,10 @@ Base.show(io::IO,v::CFVariable; indent="") = Base.show(io::IO,v.var; indent=inde
 Base.show(io::IO,::MIME"text/plain",v::Union{Variable,CFVariable}) = show(io,v)
 
 Base.display(v::Union{Variable,CFVariable}) = show(stdout,v)
+
+
+precompile(NCDataset{Nothing}, (String,))
+precompile(getindex, (NCDataset{Nothing}, String))
+precompile(getindex, (NCDataset{Nothing}, Symbol))
+precompile(variable, (NCDataset{Nothing}, String))
+precompile(NCDatasets.Variable, (Float32, 3, NCDataset))

--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -251,7 +251,7 @@ export defVar
 
 function _boundsParentVar(ds,name)
     # get from cache is available
-    if length(values(ds._boundsmap)) === 0
+    if length(values(ds._boundsmap)) > 0
         return get(ds._boundsmap,name,"")
     else
         for vname in keys(ds)
@@ -352,7 +352,6 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         calendar,time_origin,time_factor = _calendar_time(v.attrib)
     else
         calendar,time_origin,time_factor = _calendar_time(variable(ds,parentname).attrib)
-        @show calendar
         calendar,time_origin,time_factor = _calendar_time(
             v.attrib;
             calendar = calendar,

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -61,7 +61,7 @@ mutable struct NCDataset{TDS} <: AbstractDataset where TDS <: Union{AbstractData
     group::Groups{NCDataset{TDS}}
     # mapping between variables related via the bounds attribute
     # It is only used for read-only datasets to improve performance
-    _boundsmap::Union{Nothing,Dict{String,String}}
+    _boundsmap::Dict{String,String}
     function NCDataset(ncid::Integer,
                        iswritable::Bool,
                        isdefmode::Ref{Bool};
@@ -85,7 +85,7 @@ mutable struct NCDataset{TDS} <: AbstractDataset where TDS <: Union{AbstractData
         ds.attrib = Attributes(ds,NC_GLOBAL)
         ds.dim = Dimensions(ds)
         ds.group = Groups(ds)
-        ds._boundsmap = nothing
+        ds._boundsmap = Dict{String,String}()
         if !iswritable
             initboundsmap!(ds)
         end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -56,9 +56,9 @@ mutable struct NCDataset{TDS} <: AbstractDataset where TDS <: Union{AbstractData
     # true of the NetCDF is in define mode (i.e. metadata can be added, but not data)
     # need to be a reference, so that remains syncronised when copied
     isdefmode::Ref{Bool}
-    attrib::Attributes
-    dim::Dimensions
-    group::Groups
+    attrib::Attributes{NCDataset{TDS}}
+    dim::Dimensions{NCDataset{TDS}}
+    group::Groups{NCDataset{TDS}}
     # mapping between variables related via the bounds attribute
     # It is only used for read-only datasets to improve performance
     _boundsmap::Union{Nothing,Dict{String,String}}

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -62,18 +62,18 @@ function Base.getindex(a::MFGroups,name::AbstractString)
 end
 
 #---
-mutable struct MFDataset{T,N,TA,TD,TG} <: AbstractDataset where T <: AbstractDataset
+mutable struct MFDataset{T,N,S<:AbstractString,TA,TD,TG} <: AbstractDataset where T <: AbstractDataset
     ds::Array{T,N}
-    aggdim::AbstractString
+    aggdim::S
     attrib::MFAttributes{TA}
     dim::MFDimensions{TD}
     group::MFGroups{TG}
     _boundsmap::Union{Nothing,Dict{String,String}}
 end
 
-mutable struct MFVariable{T,N,M,TA} <: AbstractVariable{T,N}
+mutable struct MFVariable{T,N,M,TA,A} <: AbstractVariable{T,N}
     var::CatArrays.CatArray{T,N,M,TA}
-    attrib::MFAttributes
+    attrib::MFAttributes{A}
     dimnames::NTuple{N,String}
     varname::String
 end

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -68,7 +68,7 @@ mutable struct MFDataset{T,N,S<:AbstractString,TA,TD,TG} <: AbstractDataset wher
     attrib::MFAttributes{TA}
     dim::MFDimensions{TD}
     group::MFGroups{TG}
-    _boundsmap::Union{Nothing,Dict{String,String}}
+    _boundsmap::Dict{String,String}
 end
 
 mutable struct MFVariable{T,N,M,TA,A} <: AbstractVariable{T,N}
@@ -84,7 +84,7 @@ iswritable(mfds::MFDataset) = iswritable(mfds.ds[1])
 
 
 function MFDataset(ds,aggdim,attrib,dim,group)
-    _boundsmap = nothing
+    _boundsmap = Dict{String,String}()
     mfds = MFDataset(ds,aggdim,attrib,dim,group,_boundsmap)
     if !iswritable(mfds)
         initboundsmap!(mfds)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,10 +3,10 @@ for T in (Float16, Float32, Float64, Int16, Int32, Int64, UInt8, UInt16, UInt32)
     DS = NCDataset{Nothing}
     precompile(defVar, (DS, String, T))
     for N in (1, 2, 3, 4, 5)
-        A = Attributes{DS}
-        Var = Variable{T,N,DS}
+        A = NCDatasets.Attributes{DS}
+        Var = NCDatasets.Variable{T,N,DS}
         St = Dict{Symbol,Any}
-        CF = CFVariable{T,N,Var,A,St}
+        CF = NCDatasets.CFVariable{T,N,Var,A,St}
         precompile(Var, (DS, Cint, NTuple{N,Cint}, A))
         precompile(CF, (Var, A, St))
         precompile(dimsize, (CF,))

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,15 @@
+
+precompile(NCDataset{Nothing}, (String,))
+precompile(getindex, (NCDataset{Nothing}, String))
+precompile(getindex, (NCDataset{Nothing}, Symbol))
+precompile(variable, (NCDataset{Nothing}, String))
+
+for N in (1, 2, 3, 4, 5), 
+    T in (Float16, Float32, Float64, Int16, Int32, Int64, UInt8, UInt16, UInt32)
+    DS = NCDataset{Nothing}
+    A = NCDatasets.Attributes{DS}
+    Var = NCDatasets.Variable{T,N,DS,A}
+    St = Dict{Symbol,Any}
+    precompile(Var, (DS, Cint, NTuple{N,Cint}, A))
+    precompile(NCDatasets.CFVariable{T,N,Var,A,St}, (Var, A, St))
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,15 +1,29 @@
 
+for T in (Float16, Float32, Float64, Int16, Int32, Int64, UInt8, UInt16, UInt32)
+    DS = NCDataset{Nothing}
+    precompile(defVar, (DS, String, T))
+    for N in (1, 2, 3, 4, 5)
+        A = Attributes{DS}
+        Var = Variable{T,N,DS}
+        St = Dict{Symbol,Any}
+        CF = CFVariable{T,N,Var,A,St}
+        precompile(Var, (DS, Cint, NTuple{N,Cint}, A))
+        precompile(CF, (Var, A, St))
+        precompile(dimsize, (CF,))
+        precompile(getindex, (CF, Colon))
+        precompile(getindex, (CF, Int))
+        precompile(getindex, (CF, ntuple(Int, N)...))
+        precompile(Array, (CF,))
+        precompile(Array, (Var,))
+        precompile(show, (IO, Var,))
+        precompile(show, (IO, CF,))
+        precompile(show, (IO, MIME"text/plain", Var,))
+        precompile(show, (IO, MIME"text/plain", CF,))
+    end
+end
+
 precompile(NCDataset{Nothing}, (String,))
+precompile(keys, (NCDataset{Nothing},))
+precompile(show, (IO, NCDataset{Nothing},))
 precompile(getindex, (NCDataset{Nothing}, String))
 precompile(getindex, (NCDataset{Nothing}, Symbol))
-precompile(variable, (NCDataset{Nothing}, String))
-
-for N in (1, 2, 3, 4, 5), 
-    T in (Float16, Float32, Float64, Int16, Int32, Int64, UInt8, UInt16, UInt32)
-    DS = NCDataset{Nothing}
-    A = NCDatasets.Attributes{DS}
-    Var = NCDatasets.Variable{T,N,DS,A}
-    St = Dict{Symbol,Any}
-    precompile(Var, (DS, Cint, NTuple{N,Cint}, A))
-    precompile(NCDatasets.CFVariable{T,N,Var,A,St}, (Var, A, St))
-end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -88,7 +88,7 @@ function variable(ds::NCDataset,varname::SymbolOrString)
     attrib = Attributes(ds,varid)
 
     # reverse dimids to have the dimension order in Fortran style
-    return Variable{nctype,ndims,NCDataset,typeof(attrib)}(
+    return Variable{nctype,ndims,typeof(ds),typeof(attrib)}(
         ds,varid, (reverse(dimids)...,), attrib)
 end
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -11,11 +11,11 @@ abstract type AbstractVariable{T,N} <: AbstractArray{T,N} end
 
 # Variable (as stored in NetCDF file, without using
 # add_offset, scale_factor and _FillValue)
-mutable struct Variable{NetCDFType,N,TDS<:AbstractDataset} <: AbstractVariable{NetCDFType, N}
+mutable struct Variable{NetCDFType,N,TDS<:AbstractDataset,A<:Attributes} <: AbstractVariable{NetCDFType, N}
     ds::TDS
     varid::Cint
     dimids::NTuple{N,Cint}
-    attrib::Attributes
+    attrib::A
 end
 
 
@@ -88,9 +88,8 @@ function variable(ds::NCDataset,varname::SymbolOrString)
     attrib = Attributes(ds,varid)
 
     # reverse dimids to have the dimension order in Fortran style
-    return Variable{nctype,ndims,NCDataset}(ds,varid,
-                                  (reverse(dimids)...,),
-                                  attrib)
+    return Variable{nctype,ndims,NCDataset,typeof(attrib)}(
+        ds,varid, (reverse(dimids)...,), attrib)
 end
 
 export variable

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -11,11 +11,11 @@ abstract type AbstractVariable{T,N} <: AbstractArray{T,N} end
 
 # Variable (as stored in NetCDF file, without using
 # add_offset, scale_factor and _FillValue)
-mutable struct Variable{NetCDFType,N,TDS<:AbstractDataset,A<:Attributes} <: AbstractVariable{NetCDFType, N}
+mutable struct Variable{NetCDFType,N,TDS<:AbstractDataset} <: AbstractVariable{NetCDFType, N}
     ds::TDS
     varid::Cint
     dimids::NTuple{N,Cint}
-    attrib::A
+    attrib::Attributes{TDS}
 end
 
 
@@ -88,8 +88,7 @@ function variable(ds::NCDataset,varname::SymbolOrString)
     attrib = Attributes(ds,varid)
 
     # reverse dimids to have the dimension order in Fortran style
-    return Variable{nctype,ndims,typeof(ds),typeof(attrib)}(
-        ds,varid, (reverse(dimids)...,), attrib)
+    return Variable{nctype,ndims,typeof(ds)}(ds,varid, (reverse(dimids)...,), attrib)
 end
 
 export variable


### PR DESCRIPTION
Compilation takes a long time for NCDatasets on the first few function calls. This PR explores strategies to reduce the compile time for loading `NCDatasets` and `CFVariables`

- type stability of struct fields
- `precompile` functions
- `Dict{Symbol,Any}` instead of mixed type `NamedTuple`

Original:
```julia
julia>     using NCDatasets

julia>     filename = "/home/raf/.julia/dev/GeoData/test/data/tos_O1_2001-2002.nc"
"/home/raf/.julia/dev/GeoData/test/data/tos_O1_2001-2002.nc"

julia>     @time ds = NCDatasets.NCDataset(filename);
  0.827610 seconds (1.86 M allocations: 103.473 MiB, 8.01% gc time, 99.75% compilation time)

julia>     @time NCDatasets.variable(ds, "tos");
  0.000147 seconds (10 allocations: 880 bytes)

julia>     @time ds["tos"];
  0.570029 seconds (1.47 M allocations: 87.999 MiB, 26.39% gc time, 99.70% compilation time)
```
This PR:
```julia
julia>     using NCDatasets
[ Info: Precompiling NCDatasets [85f8d34a-cbdd-5861-8df4-14fed0d494ab]

julia>     filename = "/home/raf/.julia/dev/GeoData/test/data/tos_O1_2001-2002.nc"
"/home/raf/.julia/dev/GeoData/test/data/tos_O1_2001-2002.nc"

julia>     @time ds = NCDatasets.NCDataset(filename);
  0.626486 seconds (494.88 k allocations: 29.255 MiB, 12.36% gc time, 99.73% compilation time)

julia>     @time NCDatasets.variable(ds, "tos");
  0.000045 seconds (10 allocations: 880 bytes)

julia>     @time ds["tos"];
  0.134726 seconds (74.41 k allocations: 4.506 MiB, 99.38% compilation time)
```

It's especially faster (4x) for `getindex(::NCDataset, ::String)`. There are a lot of other optimizations that could be doe, but I'm opening this as is for now.

