### PR TITLE
Symbol attributes

### DIFF
--- a/src/netcdf_c.jl
+++ b/src/netcdf_c.jl
@@ -500,7 +500,7 @@ function nc_inq_user_type(ncid::Integer,xtype::Integer)
 end
 
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::AbstractString)
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::AbstractString)
     if name == "_FillValue"
         nc_put_att_string(ncid,varid,"_FillValue",[data])
     else
@@ -509,45 +509,45 @@ function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Abst
     end
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Vector{Char})
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Vector{Char})
     nc_put_att(ncid,varid,name,join(data))
 end
 
 # NetCDF does not necessarily support 64 bit attributes
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Int64) =
+nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Int64) =
     nc_put_att(ncid,varid,name,Int32(data))
 
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Vector{Int64}) =
+nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Vector{Int64}) =
     nc_put_att(ncid,varid,name,Int32.(data))
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Number)
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Number)
     check(ccall((:nc_put_att,libnetcdf),Cint,(Cint,Cint,Cstring,nc_type,Csize_t,Ptr{Nothing}),
                 ncid,varid,name,ncType[typeof(data)],1,[data]))
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Char)
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Char)
     # UInt8('α')
     # ERROR: InexactError: trunc(UInt8, 945)
     check(ccall((:nc_put_att,libnetcdf),Cint,(Cint,Cint,Cstring,nc_type,Csize_t,Ptr{Nothing}),
                 ncid,varid,name,ncType[typeof(data)],1,[UInt8(data)]))
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Vector{T}) where T <: AbstractString
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Vector{T}) where T <: AbstractString
     check(ccall((:nc_put_att,libnetcdf),Cint,(Cint,Cint,Cstring,
                                               nc_type,Csize_t,Ptr{Nothing}),
                 ncid,varid,name,ncType[eltype(data)],length(data),pointer.(data)))
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data::Vector{T}) where {T}
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data::Vector{T}) where {T}
     nc_put_att(ncid,varid,name,ncType[T],data)
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,typeid::Integer,data::Vector)
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,typeid::Integer,data::Vector)
     check(ccall((:nc_put_att,libnetcdf),Cint,(Cint,Cint,Cstring,nc_type,Csize_t,Ptr{Nothing}),
                 ncid,varid,name,typeid,length(data),data))
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,data)
+function nc_put_att(ncid::Integer,varid::Integer,name::SymbolOrString,data)
     error("attributes can only be scalars or vectors")
 end
 

--- a/test/test_attrib.jl
+++ b/test/test_attrib.jl
@@ -102,6 +102,11 @@ NCDatasets.NCDataset(filename,"c") do ds
     # arrays cannot be attributes
     @test_throws ErrorException v.attrib["error_attrib"] = zeros(2,2)
 
+    # symbols in the attrib dict
+    foo = NCDatasets.defVar(ds,"foovar",Int64,("lon","lat"),
+                            attrib = [:long_name => "foo variable"])
+    @test foo.attrib["long_name"] == "foo variable"
+
 end
 
 rm(filename)


### PR DESCRIPTION
Fixes breakage due to #156. Added a test to catch this, confirmed that it fails without 246dedb.