### PR TITLE
fix case where missing value is String

### DIFF
--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -366,9 +366,11 @@ function Base.getindex(ds::AbstractDataset,varname::SymbolOrString)
         end
     end
 
+    isa(missing_values,String) ? missing_values=NaN : missing_values=T.(missing_values)
+
     storage_attrib = (
         fillvalue = fillvalue,
-        missing_values = (T.(missing_values)...,),
+        missing_values = (missing_values...,),
         scale_factor = scale_factor,
         add_offset = add_offset,
         calendar = calendar,


### PR DESCRIPTION
This fixes https://github.com/Alexander-Barth/NCDatasets.jl/issues/166 

If `missing_values` is specified as text in a file then I could imagine parsing the value but that method is not full proof. In https://github.com/Alexander-Barth/NCDatasets.jl/issues/166 for example `parse(T,missing_value)` fails because the file creator set missing value to "-1.e+34f" as opposed to "-1.e+34" (no idea why).

Replacing with NaN seems like a simple solution that at least lets the user read from the file content.