### PR TITLE
add capability to read only part of continuous ragged array

### DIFF
--- a/test/test_cont_ragged_array.jl
+++ b/test/test_cont_ragged_array.jl
@@ -80,6 +80,10 @@ ds = NCDataset(fname);
 ncvar = ds["z"]
 data = loadragged(ncvar,:)
 @test data == [[1.,2.,3.],  [10.,20.],  [100., 200.]]
+data = loadragged(ncvar,1)
+@test data == [[1.,2.,3.]]
+data = loadragged(ncvar,2:3)
+@test data == [[10.,20.],  [100., 200.]]
 close(ds)
 
 rm(fname)


### PR DESCRIPTION
This modification allows calling `loadragged` with either a range (e.g., `index=10:20`) or an integer. Currently the only option is `index=:` which can be limiting, notably for larger data sets. 
