### PR TITLE
set curl options in libnetcdf via NC_rcfile_insert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
 CFTime = "0.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ CFTime = "179af706-886a-5703-950a-314cd64e0468"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
+NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
 CFTime = "0.1.1"

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -22,7 +22,6 @@ using NetworkOptions
 using NetCDF_jll
 using Dates
 using Printf
-using Scratch
 
 using Base
 using DataStructures: OrderedDict
@@ -38,19 +37,23 @@ export dayofyear, firstdayofyear
 export DateTimeStandard, DateTimeJulian, DateTimeProlepticGregorian,
     DateTimeAllLeap, DateTimeNoLeap, DateTime360Day, AbstractCFDateTime
 
-const NCRC = Ref{String}()
-
 function __init__()
-    ca_path = ca_roots()
-    if ca_path !== nothing
-        dir = get_scratch!(NetCDF_jll, "config")
-        path = joinpath(dir, ".ncrc")
-        ENV["NCRCENV_RC"] = path
-        NCRC[] = path
-        content = string("HTTP.SSL.CAINFO=", ca_path)
-        write(path, content)
+    value = ca_roots()
+    if value !== nothing
+        key = "HTTP.SSL.CAINFO"
+        hostport=C_NULL
+        path=C_NULL
+        err = @ccall(libnetcdf.NC_rcfile_insert(key::Cstring, value::Cstring, hostport::Cstring, path::Cstring)::Int32)
+        println("NC_rcfile_insert returns ", err)
+        lookup = @ccall(libnetcdf.NC_rclookup(key::Cstring, hostport::Cstring, path::Cstring)::Cstring)
+        @show lookup
+        # println(unsafe_string(lookup))
     end
 end
+
+# EXTERNL int NC_rcfile_insert(const char* key, const char* value, const char* hostport, const char* path);
+# EXTERNL char* NC_rclookup(const char* key, const char* hostport, const char* path);
+    
 
 const default_timeunits = "days since 1900-00-00 00:00:00"
 

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -18,6 +18,7 @@ More information is available at https://github.com/Alexander-Barth/NCDatasets.j
 """
 module NCDatasets
 
+using NetworkOptions
 using NetCDF_jll
 using Dates
 using Printf
@@ -35,6 +36,20 @@ export daysinmonth, daysinyear, yearmonthday, yearmonth, monthday
 export dayofyear, firstdayofyear
 export DateTimeStandard, DateTimeJulian, DateTimeProlepticGregorian,
     DateTimeAllLeap, DateTimeNoLeap, DateTime360Day, AbstractCFDateTime
+
+function __init__()
+    println("running __init__")
+    state = Ref{UInt64}(0)  # allow ocopen to write the address here
+    url = ""  # don't know what this url should be, perhaps empty is fine
+    flag = 10065  # CURLOPT_CAINFO
+    value = ca_roots()
+    @info "calling ocopen" state url
+    err = @ccall(libnetcdf.ocopen(state::Ptr{Cvoid}, url::Cstring)::Int32)
+    @info "calling ocset_curlopt" state flag value err
+    err = @ccall(libnetcdf.ocset_curlopt(state::Ptr{Cvoid}, flag::Int32, value::Cstring)::Int32)
+    println(err)
+    println("finished __init__")
+end
 
 const default_timeunits = "days since 1900-00-00 00:00:00"
 


### PR DESCRIPTION
Not working yet, but hopefully we can get there to fix #173.

I searched the netcdf-c repository and found [`ocset_curlopt`](https://github.com/Unidata/netcdf-c/blob/2404731793253c3356fbe91b54993e9d7d7df8c1/oc2/occurlfunctions.c#L24-L36), which seems to do just what we need.

However it needs a `OCstate` object. If I'm reading things right this can be created using [`ocopen`](https://github.com/Unidata/netcdf-c/blob/c147bdd7b6032192b1738c6445e9ed370e14db5c/oc2/ocinternal.c#L92-L154). That function does need a url argument, and I don't know what that should be. I put in an empty string for now.

When I run this, it crashes on calling `ocopen`, with
```
drc.c:80: ncrc_setrchome: Assertion `ncrc_globalstate && ncrc_globalstate->home' failed.
```
I don't understand this error though. This is the code:
https://github.com/Unidata/netcdf-c/blob/main/libdispatch/drc.c#L112-L123

But I don't see where `home` would be set here.
https://github.com/Unidata/netcdf-c/blob/c147bdd7b6032192b1738c6445e9ed370e14db5c/libsrc4/nc4internal.c#L2098-L2123

Ah and these seem like relevant environment variables:
```
/* getenv() keys */
#define NCRCENVIGNORE "NCRCENV_IGNORE"
#define NCRCENVRC "NCRCENV_RC"
#define NCRCENVHOME "NCRCENV_HOME"
```

This is where I got stuck, not sure how to proceed, or if I'm going about this right.