### PR TITLE
Check if NetCDF_jll `is_available` before loading code

### DIFF
--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -29,8 +29,11 @@ using Printf
 
 function __init__()
     # https://github.com/JuliaPackaging/Yggdrasil/pull/5319#issuecomment-1221042734
-    if VERSION < v"1.9"
-        init_certificate_authority()
+    try
+        if VERSION < v"1.9"
+            init_certificate_authority()
+        end
+    catch
     end
 end
 

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -29,11 +29,8 @@ using Printf
 
 function __init__()
     # https://github.com/JuliaPackaging/Yggdrasil/pull/5319#issuecomment-1221042734
-    try
-        if VERSION < v"1.9"
-            init_certificate_authority()
-        end
-    catch
+    if VERSION < v"1.9"
+        NetCDF_jll.is_available() && init_certificate_authority()
     end
 end
 


### PR DESCRIPTION
This change makes it possible to `using NCDatasets` on systems without NetCDF (due to eg #150).

X-ref: https://github.com/CliMA/Oceananigans.jl/pull/2847

cc @navidcy