### PR TITLE
Throw informative error for unsupported vtype

### DIFF
--- a/src/cfvariable.jl
+++ b/src/cfvariable.jl
@@ -114,6 +114,7 @@ function defVar(ds::NCDataset,name::SymbolOrString,vtype::DataType,dimnames;
             typeid = nc_def_vlen(ds.ncid, typename, ncType[eltype(vtype)])
         else
             # base-type
+            haskey(ncType, vtype) || error("$vtype not supported")
             ncType[vtype]
         end
 

--- a/test/test_writevar.jl
+++ b/test/test_writevar.jl
@@ -12,6 +12,8 @@ ds = NCDataset(filename,"c")
 defDim(ds,"lon",sz[1])
 defDim(ds,"lat",sz[2])
 
+# vartype not supported
+@test_throws ErrorException defVar(ds,"var-DT",DateTime,("lon","lat"))
 
 # variables
 for T in [UInt8,Int8,UInt16,Int16,UInt32,Int32,UInt64,Int64,Float32,Float64]


### PR DESCRIPTION
Currently, defVar fails with something like
```
ERROR: KeyError: key DateTime not found
```
This PR throws a more informative error message