### PR TITLE
type-stable `variable`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 
 [targets]
-test = ["Dates", "Test", "Random", "Printf", "IntervalSets"]
+test = ["Dates", "Test", "Random", "Printf", "IntervalSets", "JET"]

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -75,13 +75,34 @@ end
 
 """
     v = variable(ds::NCDataset,varname::String)
+    v = variable(ds, varname, DType, dimnames)
 
 Return the NetCDF variable `varname` in the dataset `ds` as a
 `NCDataset.Variable`. No scaling or other transformations are applied when the
 variable `v` is indexed.
+
+With the second form, supplying the correct data `DType` (e.g. `Float32`) 
+and `dimnames` (a tuple, e.g. `("lat", "lon")`) can lets you read in a type-stable way.
+
+!!! note
+
+    Incorrectly specified `DType` or `dimnames` can lead to incorrect
+    results (e.g. "garbage" output) with no errors, so proceed with caution.
 """
 variable(ds::NCDataset,varname::AbstractString) = _variable(ds,varname)
 variable(ds::NCDataset,varname::Symbol) = _variable(ds,varname)
+
+function variable(
+    ds::NCDataset, 
+    varname::Union{AbstractString, Symbol}, 
+    DType::DataType, 
+    dimnames::NTuple{N, AbstractString},
+) where {N}
+    dimids = nc_inq_dimid.(ds.ncid, dimnames)
+    varid = nc_inq_varid(ds.ncid, varname)
+    Variable{DType, N, typeof(ds)}(ds, varid, dimids)
+end
+
 
 export variable
 

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -3,6 +3,7 @@ using Dates
 using Printf
 using NCDatasets
 using DataStructures
+import JET
 
 sz = (4,5)
 filename = tempname()
@@ -316,3 +317,19 @@ NCDatasets.load!(variable(ds, "temperature"), v, CartesianIndices((1:10,10:30)))
 vv = [1.0f0]
 NCDatasets.load!(variable(ds, "temperature"), vv, CartesianIndex(5,5))
 @test vv[1] == data[CartesianIndex(5,5)]
+
+### Test type stability of `variable(ds, varname, DType, dimnames)`
+JET.@test_opt variable(ds, "temperature", Float32, ("lon", "lat"))
+# Note: Incorrect order of `dimnames` doesn't error if slices are within bounds...
+var1 = variable(ds, "temperature", Float32, ("lon", "lat"))[1:5, 1:10]
+var2 = variable(ds, "temperature", Float32, ("lat", "lon"))[1:5, 1:10]  # TODO: Ensure this errors
+@test var1 == var2
+# ... but incorrect order of `dimnames` and out-of-bounds slices errors
+@test_throws variable(ds, "temperature", Float32, ("lat", "lon"))[:, 1]  # `:` is actually `1:110`
+# incorrect `dimnames` errors
+@test_throws variable(ds, "temperature", Float32, ("lon", "lat", "time"))
+@test_throws variable(ds, "temperature", Float32, ("lon",))
+# Incorrect `DType` doesn't error, but gives incorrect result
+d1 = variable(ds, "temperature", Float32, ("lon", "lat"))[1:5, 1:3]
+d2 = variable(ds, "temperature", Float64, ("lon", "lat"))[1:5, 1:3]
+@test d1 != d2  # TODO: Ensure this errors


### PR DESCRIPTION
This is an attempt to write a type-stable variant of `variable`, which enables completely type stable reading of data from NetCDF files.

Currently, reading data is not type stable since at read-time Julia doesn't know the type of the data to be read, nor the number of dimensions. See for example:
```julia
@code_warntype variable(ds, "temperature")

@code_warntype ds["temperature"]
```
<details><summary>output</summary>

```julia
julia> @code_warntype variable(ds, "temperature")
MethodInstance for CommonDataModel.variable(::NCDataset{Nothing, Missing}, ::String)
  from variable(ds::NCDataset, varname::AbstractString) @ NCDatasets ~/.julia/packages/NCDatasets/JrRxr/src/variable.jl:83
Arguments
  #self#::Core.Const(CommonDataModel.variable)
  ds::NCDataset{Nothing, Missing}
  varname::String
Body::NCDatasets.Variable{_A, _B, NCDataset{Nothing, Missing}} where {_A, _B}
1 ─ %1 = NCDatasets._variable(ds, varname)::NCDatasets.Variable{_A, _B, NCDataset{Nothing, Missing}} where {_A, _B}
└──      return %1
# "Body" is not inferred

julia> @code_warntype ds["temperature"]
MethodInstance for getindex(::NCDataset{Nothing, Missing}, ::String)
  from getindex(ds::CommonDataModel.AbstractDataset, varname::Union{AbstractString, Symbol}) @ CommonDataModel ~/.julia/packages/CommonDataModel/GGvMn/src/dataset.jl:169
Arguments
  #self#::Core.Const(getindex)
  ds::NCDataset{Nothing, Missing}
  varname::String
Body::CommonDataModel.CFVariable{_A, _B, NCDatasets.Variable{_A1, _B1, NCDataset{Nothing, Missing}}, CommonDataModel.Attributes{TDS}, NamedTuple{(:fillvalue, :missing_values, :scale_factor, :add_offset, :calendar, :time_origin, :time_factor, :maskingvalue), var"#s178"}} where {_A, _B, _A1, _B1, TDS<:(NCDatasets.Variable{_A, _B, NCDataset{Nothing, Missing}} where {_A, _B}), var"#s178"<:Tuple{Any, Tuple, Any, Any, Any, Any, Union{Nothing, Int64}, Missing}}
1 ─ %1 = CommonDataModel.cfvariable(ds, varname)::CommonDataModel.CFVariable{_A, _B, NCDatasets.Variable{_A1, _B1, NCDataset{Nothing, Missing}}, CommonDataModel.Attributes{TDS}, NamedTuple{(:fillvalue, :missing_values, :scale_factor, :add_offset, :calendar, :time_origin, :time_factor, :maskingvalue), var"#s178"}} where {_A, _B, _A1, _B1, TDS<:(NCDatasets.Variable{_A, _B, NCDataset{Nothing, Missing}} where {_A, _B}), var"#s178"<:Tuple{Any, Tuple, Any, Any, Any, Any, Union{Nothing, Int64}, Missing}}
└──      return %1
# "Body" is not inferred
```

</details>

In some cases you have both these pieces of information. This PR extends `variable` with another signature on the form `variable(ds, varname, DType, dimnames)` where `ds` and `varname` is as before. Now also supplied is the data type `DType` (e.g. `Float32`) and dimension names `dimnames` (e.g. `("lon", "lat")` or `("time",)`).

Supplying incorrect `dimnames` errors. However, correct `dimnames`, but ordered incorrectly, does not error (and in fact gives "correct" results) unless you go out-of-bonds of the stored data (see tests for an example).

More worryingly, providing incorrect `DType` gives garbage output with no warning. As such, it might be preferable to give this function a more scary name such as `unsafe_variable` and not export it (like `load!`).
<details><summary> example of incorrect loading</summary>

```julia
julia> d1 = __variable(ds, "temperature", Float32, ("lon", "lat"))[1:5, 1:3]
5×3 Matrix{Float32}:
 2.0  3.0  4.0
 3.0  4.0  5.0
 4.0  5.0  6.0
 5.0  6.0  7.0
 6.0  7.0  8.0

julia> d2 = __variable(ds, "temperature", Float64, ("lon", "lat"))[1:5, 1:3]
5×3 Matrix{Float64}:
    32.0   2048.0           5.4e-323
  2048.0  32768.0           6.0e-323
    32.0      5.38788e-315  6.4e-323
  2048.0      4.4e-323      7.0e-323
 32768.0      5.0e-323      7.4e-323

julia> __variable(ds, "temperature", Int32, ("lon", "lat"))[1:5, 1:3]
5×3 Matrix{Int32}:
 1073741824  1077936128  1082130432
 1077936128  1082130432  1084227584
 1082130432  1084227584  1086324736
 1084227584  1086324736  1088421888
 1086324736  1088421888  1090519040
```

</details>

------
Other info
<details><summary>create dataset for above examples</summary>

```julia
fname = tempname()
ds = NCDataset(fname,"c")
defDim(ds,"lon",100)
defDim(ds,"lat",110)
v = defVar(ds,"temperature",Float32,("lon","lat"))
data = [Float32(i+j) for i = 1:100, j = 1:110];
v[:,:] = data;
close(ds)

# reading
ds = NCDataset(fname)
```
</details>